### PR TITLE
fix: add debounce time to request in SearchBar component

### DIFF
--- a/src/components/SearchBar/SearchBar.js
+++ b/src/components/SearchBar/SearchBar.js
@@ -22,9 +22,13 @@ function SearchBar({ toggleSearchBar }) {
   } = useFetch(request)
 
   useEffect(() => {
-    if (value) {
-      setRequest(getSuggestions({ keyword: value }))
-    }
+    const timerId = setTimeout(() => {
+      if (value) {
+        setRequest(getSuggestions({ keyword: value }))
+      }
+    }, 200)
+
+    return () => clearTimeout(timerId)
   }, [value])
 
   const handleOnChange = (e) => setValue(e.target.value)


### PR DESCRIPTION
# Fix 35 SearchBar debounce

## Issue: #35 

## Resumen o descripción:
* Se agregó un timeout de 200 ms para ejecutar la función ``setRequest`` con el objetivo de prevenir que se realicen solicitudes muy frecuentemente mientras se ingresan valores por el teclado.