### PR TITLE
Fix 51 max with home container

### DIFF
--- a/src/components/HorizontalVideoPreview/styles.js
+++ b/src/components/HorizontalVideoPreview/styles.js
@@ -8,7 +8,6 @@ const styles = css`
     left: 0;
     right: 0;
     padding-bottom: 56.25%;
-    margin: auto;
     overflow: hidden;
   }
 

--- a/src/components/VideoPreview/styles.js
+++ b/src/components/VideoPreview/styles.js
@@ -9,7 +9,6 @@ const styles = css`
     right: 0;
     width: 100%;
     padding-bottom: 56.25%;
-    margin: auto;
     overflow: hidden;
   }
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -36,7 +36,7 @@ function Home() {
       </Head>
 
       <WebsiteLayout>
-        <div className='py-2 grid gap-4 grid-cols-1 sm:grid-cols-2 sm:p-4 md:grid-cols-3 xl:grid-cols-4 xl:p-5'>
+        <div className='py-2 grid gap-4 grid-cols-1 sm:grid-cols-2 sm:p-4 md:grid-cols-3 xl:grid-cols-4 xl:p-5 lg:max-w-screen-2xl lg:mx-auto'>
           {isLoading &&
             [1, 2, 3, 4, 5, 6].map((i) => (
               <div className="flex" key={i}>


### PR DESCRIPTION
# Fix 51 max width from home page container

## Issue: #51

## Resumen o descripción:
* Se agregó un ``max-width`` de ``1536px`` al contenedor principal de la página home.
* Se removió el margin auto de los contenedores de imágenes en los componentes ``VideoPreview`` y ``HorizontalVideoPreview``.